### PR TITLE
Dependabot doesn't work with submodules.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    allow:
-      - dependency-name: "extlib/libsonata"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
It can only update to the latest version of `master` which is pointless.